### PR TITLE
Support Visual Studio 2017

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "Invoke-Pester",
+            "script": "Invoke-Pester",
+            "cwd": "${workspaceRoot}"
+        }
+    ]
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 # AppVeyor build definition
 # http://www.appveyor.com/docs/appveyor-yml
 
-version: 0.1.{build}
+version: 0.2.{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/readme.md
+++ b/readme.md
@@ -1,46 +1,69 @@
 # posh-vs
 
-Makes Visual Studio 2015 command line tools available in PowerShell. 
+Makes Visual Studio command line tools available in PowerShell. Supports Visual Studio 2017 and 2015.
 
 ## Usage
 
 Install posh-vs from the [PowerShell Gallery](https://www.powershellgallery.com/packages/posh-vs):
-``` 
+```
 PS> Install-Module posh-vs -Scope CurrentUser
+```
+
+Change your PowerShell profile to automatically import Visual Studio developer environment.
+```
 PS> Install-PoshVs
-``` 
+```
 
 Start a new PowerShell session or reload your profile:
-``` 
+```
 PS> . $profile
 ```
 
-Use Visual Studio 2015 command line tools in PowerShell:
+Use Visual Studio command line tools in PowerShell:
 ``` 
 PS> msbuild /?
 ```
 
+## How it works
+
+`Install-PoshVs` adds a `Import-VisualStudioBatchEnvironment` call to the PowerShell `$profile`. It will import the
+environment variables set by the `VsDevCmd.bat` of the latest version of Visual Studio installed on your computer.
+If multiple instances of Visual Studio 2017 are installed, `Import-VisualStudioBatchEnvironment` will use whichever
+instance happens to be listed first.
+
+To use a specific instance of Visual Studio 2017, manually change your profile to import a specific batch file.
+```
+Import-BatchEnvironment 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat'
+```
+
 ## Uninstall
 
-``` 
+Remove posh-vs from your PowerShell profile.
+```
 PS> Uninstall-PoshVs
-PS> Uninstall-Module posh-vs
 PS> exit
 ```
 
-## Development
+Uninstall posh-vs from your computer.
+```
+PS> Uninstall-Module posh-vs
+```
+
+## Develop
 
 [![Build status](https://ci.appveyor.com/api/projects/status/github/olegsych/posh-vs?branch=master)](https://ci.appveyor.com/project/olegsych/posh-vs/branch/master)
 
 Install pre-requisites.
-``` 
+```
 PS> .\init.ps1
 ```
 
 `Ctrl+Shift+B` to build and test in [VSCode](https://code.visualstudio.com) or
-``` 
+```
 PS> Invoke-psake
 ```
+
+`F5` to debug tests in VSCode.
 
 ## Credits
 

--- a/readme.md
+++ b/readme.md
@@ -26,10 +26,11 @@ PS> msbuild /?
 
 ## How it works
 
-`Install-PoshVs` adds a `Import-VisualStudioBatchEnvironment` call to the PowerShell `$profile`. It will import the
-environment variables set by the `VsDevCmd.bat` of the latest version of Visual Studio installed on your computer.
-If multiple instances of Visual Studio 2017 are installed, `Import-VisualStudioBatchEnvironment` will use whichever
-instance happens to be listed first.
+`Install-PoshVs` adds an `Import-VisualStudioBatchEnvironment` call to the PowerShell
+[profile](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.core/about/about_profiles).
+It will import the environment variables set by the `VsDevCmd.bat` of the latest version of Visual Studio installed
+on your computer. If multiple instances of Visual Studio 2017 are installed, `Import-VisualStudioBatchEnvironment`
+will use whichever instance happens to be listed first.
 
 To use a specific instance of Visual Studio 2017, manually change your profile to import a specific batch file.
 ```

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -2,6 +2,14 @@
 param()
 
 <# .SYNOPSIS 
+Returns full path to the Visual Studio 2015's VsDevCmd.bat #>
+function Get-VisualStudio2015BatchFile {
+    if ($env:VS140ComnTools) {
+        Join-Path $env:VS140ComnTools "VsDevCmd.bat"
+    }
+}
+
+<# .SYNOPSIS 
 Executes a batch file and copies environment variables it sets to the current
 PowerShell session #>
 function Import-BatchEnvironment {
@@ -80,6 +88,7 @@ function Uninstall-PoshVs {
     Write-Output "Restart PowerShell for the changes to take effect."
 }
 
+Export-ModuleMember -Function Get-VisualStudio2015BatchFile
 Export-ModuleMember -Function Import-BatchEnvironment
 Export-ModuleMember -Function Import-VisualStudioEnvironment
 Export-ModuleMember -Function Install-PoshVs

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -9,8 +9,6 @@ function Get-VisualStudio2015BatchFile {
     }
 }
 
-<# .SYNOPSIS
-Returns ApplicationDescription registry entries of all installed Visual Studio 2017 instances #>
 function Get-VisualStudio2017ApplicationDescription {
     & {
         Get-ItemProperty HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio_*\Capabilities
@@ -18,8 +16,6 @@ function Get-VisualStudio2017ApplicationDescription {
     } | ForEach-Object { $_.ApplicationDescription }
 }
 
-<# .SYNOPSIS
-Returns full path to VsDevCmd.bat of all installed Visual Studio 2017 instances #>
 function Get-VisualStudio2017BatchFile {
     Get-VisualStudio2017ApplicationDescription |
     ForEach-Object {
@@ -119,7 +115,6 @@ function Uninstall-PoshVs {
 }
 
 Export-ModuleMember -Function Get-VisualStudio2015BatchFile
-Export-ModuleMember -Function Get-VisualStudio2017BatchFile
 Export-ModuleMember -Function Get-VisualStudioBatchFile
 Export-ModuleMember -Function Import-BatchEnvironment
 Export-ModuleMember -Function Import-VisualStudioEnvironment

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -1,7 +1,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Scope="Function", Target="*-PoshVS", Justification="PoshVs is a singular noun")]        
 param()
 
-<# .SYNOPSIS 
+<# .SYNOPSIS
 Returns full path to VsDevCmd.bat of Visual Studio 2017 if it's installed #>
 function Get-VisualStudio2015BatchFile {
     if ($env:VS140ComnTools) {
@@ -9,9 +9,23 @@ function Get-VisualStudio2015BatchFile {
     }
 }
 
-<# .SYNOPSIS 
+<# .SYNOPSIS
+Returns ApplicationDescription registry entries of all installed Visual Studio 2017 instances #>
+function Get-VisualStudio2017ApplicationDescription {
+}
+
+<# .SYNOPSIS
 Returns full path to VsDevCmd.bat of all installed Visual Studio 2017 instances #>
 function Get-VisualStudio2017BatchFile {
+    Get-VisualStudio2017ApplicationDescription |
+    ForEach-Object {
+        # @C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\devenvdesc.dll,-1004
+        if ($_ -match '@(?<Common7>.*)\\IDE\\devenvdesc.dll,-(?:\d*)') {
+            return Join-Path $matches.Common7 'Tools\VsDevCmd.bat'
+        }
+
+        throw "Cannot parse Visual Studio ApplicationDescription: $_"
+    }
 }
 
 <# .SYNOPSIS
@@ -101,6 +115,7 @@ function Uninstall-PoshVs {
 }
 
 Export-ModuleMember -Function Get-VisualStudio2015BatchFile
+Export-ModuleMember -Function Get-VisualStudio2017ApplicationDescription
 Export-ModuleMember -Function Get-VisualStudio2017BatchFile
 Export-ModuleMember -Function Get-VisualStudioBatchFile
 Export-ModuleMember -Function Import-BatchEnvironment

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -12,6 +12,10 @@ function Get-VisualStudio2015BatchFile {
 <# .SYNOPSIS
 Returns ApplicationDescription registry entries of all installed Visual Studio 2017 instances #>
 function Get-VisualStudio2017ApplicationDescription {
+    & {
+        Get-ItemProperty HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio_*\Capabilities
+        Get-ItemProperty HKLM:\SOFTWARE\Microsoft\VisualStudio_*\Capabilities
+    } | ForEach-Object { $_.ApplicationDescription }
 }
 
 <# .SYNOPSIS
@@ -115,7 +119,6 @@ function Uninstall-PoshVs {
 }
 
 Export-ModuleMember -Function Get-VisualStudio2015BatchFile
-Export-ModuleMember -Function Get-VisualStudio2017ApplicationDescription
 Export-ModuleMember -Function Get-VisualStudio2017BatchFile
 Export-ModuleMember -Function Get-VisualStudioBatchFile
 Export-ModuleMember -Function Import-BatchEnvironment

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -1,8 +1,6 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Scope="Function", Target="*-PoshVS", Justification="PoshVs is a singular noun")]        
 param()
 
-<# .SYNOPSIS
-Returns full path to VsDevCmd.bat of Visual Studio 2017 if it's installed #>
 function Get-VisualStudio2015BatchFile {
     if ($env:VS140ComnTools) {
         Join-Path $env:VS140ComnTools "VsDevCmd.bat"
@@ -114,7 +112,6 @@ function Uninstall-PoshVs {
     Write-Output "Restart PowerShell for the changes to take effect."
 }
 
-Export-ModuleMember -Function Get-VisualStudio2015BatchFile
 Export-ModuleMember -Function Get-VisualStudioBatchFile
 Export-ModuleMember -Function Import-BatchEnvironment
 Export-ModuleMember -Function Import-VisualStudioEnvironment

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -58,11 +58,7 @@ function Import-BatchEnvironment {
 Executes Visual Studio 2015's VsDevCmd.bat and copies environment variables it sets
 to the current PowerShell session. #>
 function Import-VisualStudioEnvironment {
-    if (-not $env:VS140COMNTOOLS) {
-        Throw "Unable to determine location of Visual Studio 2015. The VS140COMNTOOLS environment is not set."
-    }
-
-    [string] $batchFile = (Join-Path $env:VS140COMNTOOLS "VsDevCmd.bat")
+    [string] $batchFile = Get-VisualStudioBatchFile | Select-Object -First 1
     Import-BatchEnvironment $batchFile
 }
 

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -2,11 +2,23 @@
 param()
 
 <# .SYNOPSIS 
-Returns full path to the Visual Studio 2015's VsDevCmd.bat #>
+Returns full path to VsDevCmd.bat of Visual Studio 2017 if it's installed #>
 function Get-VisualStudio2015BatchFile {
     if ($env:VS140ComnTools) {
         Join-Path $env:VS140ComnTools "VsDevCmd.bat"
     }
+}
+
+<# .SYNOPSIS 
+Returns full path to VsDevCmd.bat of all installed Visual Studio 2017 instances #>
+function Get-VisualStudio2017BatchFile {
+}
+
+<# .SYNOPSIS
+Returns paths to VsDevCmd.bat files of all installed Visual Studio instances #>
+function Get-VisualStudioBatchFile {
+    Get-VisualStudio2017BatchFile
+    Get-VisualStudio2015BatchFile
 }
 
 <# .SYNOPSIS 
@@ -89,6 +101,8 @@ function Uninstall-PoshVs {
 }
 
 Export-ModuleMember -Function Get-VisualStudio2015BatchFile
+Export-ModuleMember -Function Get-VisualStudio2017BatchFile
+Export-ModuleMember -Function Get-VisualStudioBatchFile
 Export-ModuleMember -Function Import-BatchEnvironment
 Export-ModuleMember -Function Import-VisualStudioEnvironment
 Export-ModuleMember -Function Install-PoshVs

--- a/src/posh-vs.psm1
+++ b/src/posh-vs.psm1
@@ -26,8 +26,6 @@ function Get-VisualStudio2017BatchFile {
     }
 }
 
-<# .SYNOPSIS
-Returns paths to VsDevCmd.bat files of all installed Visual Studio instances #>
 function Get-VisualStudioBatchFile {
     Get-VisualStudio2017BatchFile
     Get-VisualStudio2015BatchFile
@@ -112,7 +110,6 @@ function Uninstall-PoshVs {
     Write-Output "Restart PowerShell for the changes to take effect."
 }
 
-Export-ModuleMember -Function Get-VisualStudioBatchFile
 Export-ModuleMember -Function Import-BatchEnvironment
 Export-ModuleMember -Function Import-VisualStudioEnvironment
 Export-ModuleMember -Function Install-PoshVs

--- a/test/posh-vs.tests.ps1
+++ b/test/posh-vs.tests.ps1
@@ -289,15 +289,15 @@ Describe 'Get-VisualStudio2017BatchFile' {
 
     InModuleScope posh-vs {
         Context 'Expected string from Get-VisualStudio2017ApplicationDescription' {
-            It 'Returns VsDevCmd.bat paths relative to location of devenvdesc.dll' {
-                [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
-                [string] $instance1RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
-                [string] $instance2RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
-                Mock Get-VisualStudio2017ApplicationDescription {
-                    "@$instance1RootPath\Common7\IDE\devenvdesc.dll,-1234"
-                    "@$instance2RootPath\Common7\IDE\devenvdesc.dll,-321"
-                }.GetNewClosure()
+            [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+            [string] $instance1RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
+            [string] $instance2RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
+            Mock Get-VisualStudio2017ApplicationDescription {
+                "@$instance1RootPath\Common7\IDE\devenvdesc.dll,-1234"
+                "@$instance2RootPath\Common7\IDE\devenvdesc.dll,-321"
+            }.GetNewClosure()
 
+            It 'Returns VsDevCmd.bat paths relative to location of devenvdesc.dll' {
                 Get-VisualStudio2017BatchFile | Should Be @(
                     "$instance1RootPath\Common7\Tools\VsDevCmd.bat"
                     "$instance2RootPath\Common7\Tools\VsDevCmd.bat"
@@ -306,12 +306,12 @@ Describe 'Get-VisualStudio2017BatchFile' {
         }
 
         Context 'Unexpected string from Get-VisualStudio2017ApplicationDescription' {
-            It 'Throws descriptive error' {
-                [string] $unexpected = 'unexpected'
-                Mock Get-VisualStudio2017ApplicationDescription {
-                    $unexpected
-                }.GetNewClosure()
+            [string] $unexpected = 'unexpected'
+            Mock Get-VisualStudio2017ApplicationDescription {
+                $unexpected
+            }.GetNewClosure()
 
+            It 'Throws descriptive error' {
                 { Get-VisualStudio2017BatchFile } | Should Throw "Cannot parse Visual Studio ApplicationDescription: $unexpected"
             }
         }

--- a/test/posh-vs.tests.ps1
+++ b/test/posh-vs.tests.ps1
@@ -41,6 +41,19 @@ Describe "posh-vs" {
         }
     }
 
+    Context 'Get-VisualStudioBatchFile' {
+        It 'Returns VsDevCmd.bat of Visual Studio 2017 followed by those of Visual Studio 2015' {
+            [string] $vs2017BatchFile1 = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+            [string] $vs2017BatchFile2 = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+            Mock Get-VisualStudio2017BatchFile { @($vs2017BatchFile1, $vs2017BatchFile2) }.GetNewClosure() -ModuleName posh-vs
+
+            [string] $vs2015BatchFile = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+            Mock Get-VisualStudio2015BatchFile { $vs2015BatchFile }.GetNewClosure() -ModuleName posh-vs
+
+            Get-VisualStudioBatchFile | Should Be @($vs2017BatchFile1, $vs2017BatchFile2, $vs2015BatchFile)
+        }
+    }
+
     Context "Import-BatchEnvironment" {
         [string] $batchFile
         [string] $variable

--- a/test/posh-vs.tests.ps1
+++ b/test/posh-vs.tests.ps1
@@ -15,32 +15,6 @@ Describe "posh-vs" {
         $global:profile = $originalProfile
     }
 
-    Context "Get-VisualStudio2015BatchFile" {
-        [string] $originalPath
-
-        BeforeEach {
-            $originalPath = $env:VS140ComnTools
-        }
-
-        It 'Returns path to VsDevCmd.bat when $env:V140ComnTools is defined' {
-            $env:VS140ComnTools = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
-
-            Get-VisualStudio2015BatchFile | Should Be (Join-Path $env:VS140ComnTools "VsDevCmd.bat")
-        }
-
-        It 'Does not return path to VsDevCmd.bat when $env:V140ComnTools is not defined' {
-            if ($env:VS140ComnTools) {
-                Remove-Item "env:\VS140COMNTOOLS"
-            }
-
-            Get-VisualStudio2015BatchFile | Should BeNullOrEmpty
-        }
-
-        AfterEach {
-            $env:VS140ComnTools = $originalPath
-        }
-    }
-
     Context 'Get-VisualStudioBatchFile' {
         It 'Returns VsDevCmd.bat of Visual Studio 2017 followed by those of Visual Studio 2015' {
             [string] $vs2017BatchFile1 = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
@@ -218,6 +192,42 @@ Describe "posh-vs" {
                 "Successfully removed posh-vs from profile '$global:profile'."
                 "Restart PowerShell for the changes to take effect."
             )
+        }
+    }
+
+    Remove-Module posh-vs
+}
+
+Describe 'Get-VisualStudio2015BatchFile' {
+    Import-Module $PSScriptRoot\..\src\posh-vs.psm1
+
+    InModuleScope posh-vs {
+        [string] $originalPath
+
+        BeforeEach {
+            $originalPath = $env:VS140ComnTools
+        }
+
+        Context '$env:V140ComnTools is defined' {
+            $env:VS140ComnTools = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+
+            It 'Returns path to VsDevCmd.bat' {
+                Get-VisualStudio2015BatchFile | Should Be (Join-Path $env:VS140ComnTools "VsDevCmd.bat")
+            }
+        }
+
+        Context '$env:V140ComnTools is not defined' {
+            if ($env:VS140ComnTools) {
+                Remove-Item 'env:\VS140COMNTOOLS'
+            }
+
+            It 'Returns nothing' {
+                Get-VisualStudio2015BatchFile | Should BeNullOrEmpty
+            }
+        }
+
+        AfterEach {
+            $env:VS140ComnTools = $originalPath
         }
     }
 

--- a/test/posh-vs.tests.ps1
+++ b/test/posh-vs.tests.ps1
@@ -15,6 +15,32 @@ Describe "posh-vs" {
         $global:profile = $originalProfile
     }
 
+    Context "Get-VisualStudio2015BatchFile" {
+        [string] $originalPath
+
+        BeforeEach {
+            $originalPath = $env:VS140ComnTools
+        }
+
+        It 'Returns path to VsDevCmd.bat when $env:V140ComnTools is defined' {
+            $env:VS140ComnTools = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+
+            Get-VisualStudio2015BatchFile | Should Be (Join-Path $env:VS140ComnTools "VsDevCmd.bat")
+        }
+
+        It 'Does not return path to VsDevCmd.bat when $env:V140ComnTools is not defined' {
+            if ($env:VS140ComnTools) {
+                Remove-Item "env:\VS140COMNTOOLS"
+            }
+
+            Get-VisualStudio2015BatchFile | Should BeNullOrEmpty
+        }
+
+        AfterEach {
+            $env:VS140ComnTools = $originalPath
+        }
+    }
+
     Context "Import-BatchEnvironment" {
         [string] $batchFile
         [string] $variable

--- a/test/posh-vs.tests.ps1
+++ b/test/posh-vs.tests.ps1
@@ -41,32 +41,6 @@ Describe "posh-vs" {
         }
     }
 
-    Context 'Get-VisualStudio2017BatchFile' {
-        It 'Returns VsDevCmd.bat paths determined based on Visual Studio 2017 application descriptions' {
-            [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
-            [string] $instance1RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
-            [string] $instance2RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
-            Mock Get-VisualStudio2017ApplicationDescription -ModuleName posh-vs {
-                "@$instance1RootPath\Common7\IDE\devenvdesc.dll,-1234"
-                "@$instance2RootPath\Common7\IDE\devenvdesc.dll,-321"
-            }.GetNewClosure()
-
-            Get-VisualStudio2017BatchFile | Should Be @(
-                "$instance1RootPath\Common7\Tools\VsDevCmd.bat"
-                "$instance2RootPath\Common7\Tools\VsDevCmd.bat"
-            )
-        }
-
-        It 'Throws descriptive error when Get-VisualStudio2017ApplicationDescription returns unexpected string' {
-            [string] $unexpected = 'unexpected'
-            Mock Get-VisualStudio2017ApplicationDescription -ModuleName posh-vs {
-                $unexpected
-            }.GetNewClosure()
-
-            { Get-VisualStudio2017BatchFile } | Should Throw "Cannot parse Visual Studio ApplicationDescription: $unexpected"
-        }
-    }
-
     Context 'Get-VisualStudioBatchFile' {
         It 'Returns VsDevCmd.bat of Visual Studio 2017 followed by those of Visual Studio 2015' {
             [string] $vs2017BatchFile1 = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
@@ -293,6 +267,42 @@ Describe 'Get-VisualStudio2017ApplicationDescription' {
                     $applicationDescription1
                     $applicationDescription2
                 )
+            }
+        }
+    }
+
+    Remove-Module posh-vs
+}
+
+Describe 'Get-VisualStudio2017BatchFile' {
+    Import-Module $PSScriptRoot\..\src\posh-vs.psm1
+
+    InModuleScope posh-vs {
+        Context 'Expected string from Get-VisualStudio2017ApplicationDescription' {
+            It 'Returns VsDevCmd.bat paths relative to location of devenvdesc.dll' {
+                [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+                [string] $instance1RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
+                [string] $instance2RootPath = Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName())
+                Mock Get-VisualStudio2017ApplicationDescription {
+                    "@$instance1RootPath\Common7\IDE\devenvdesc.dll,-1234"
+                    "@$instance2RootPath\Common7\IDE\devenvdesc.dll,-321"
+                }.GetNewClosure()
+
+                Get-VisualStudio2017BatchFile | Should Be @(
+                    "$instance1RootPath\Common7\Tools\VsDevCmd.bat"
+                    "$instance2RootPath\Common7\Tools\VsDevCmd.bat"
+                )
+            }
+        }
+
+        Context 'Unexpected string from Get-VisualStudio2017ApplicationDescription' {
+            It 'Throws descriptive error' {
+                [string] $unexpected = 'unexpected'
+                Mock Get-VisualStudio2017ApplicationDescription {
+                    $unexpected
+                }.GetNewClosure()
+
+                { Get-VisualStudio2017BatchFile } | Should Throw "Cannot parse Visual Studio ApplicationDescription: $unexpected"
             }
         }
     }

--- a/test/posh-vs.tests.ps1
+++ b/test/posh-vs.tests.ps1
@@ -243,17 +243,17 @@ Describe 'Get-VisualStudio2017ApplicationDescription' {
         }
 
         Context 'In a 64-bit PowerShell process' {
-            It 'Returns ApplicationDescription property HKLM:\SOFTWARE\WOW6432Node' {
-                [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
-                [string] $applicationDescription1 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
-                [string] $applicationDescription2 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
-                Mock Get-ItemProperty -MockWith {
-                    @{ ApplicationDescription = $applicationDescription1 }
-                    @{ ApplicationDescription = $applicationDescription2 }
-                }.GetNewClosure() -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio_*\Capabilities'
-                }
+            [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+            [string] $applicationDescription1 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
+            [string] $applicationDescription2 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
+            Mock Get-ItemProperty -MockWith {
+                @{ ApplicationDescription = $applicationDescription1 }
+                @{ ApplicationDescription = $applicationDescription2 }
+            }.GetNewClosure() -ParameterFilter {
+                $Path -eq 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio_*\Capabilities'
+            }
 
+            It 'Returns ApplicationDescription property HKLM:\SOFTWARE\WOW6432Node' {
                 Get-VisualStudio2017ApplicationDescription | Should Be @(
                     $applicationDescription1
                     $applicationDescription2
@@ -262,17 +262,17 @@ Describe 'Get-VisualStudio2017ApplicationDescription' {
         }
 
         Context 'In a 32-bit PowerShell process' {
-            It 'Returns ApplicationDescription property from HKLM:\SOFTWARE' {
-                [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
-                [string] $applicationDescription1 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
-                [string] $applicationDescription2 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
-                Mock Get-ItemProperty -MockWith {
-                    @{ ApplicationDescription = $applicationDescription1 }
-                    @{ ApplicationDescription = $applicationDescription2 }
-                }.GetNewClosure() -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\VisualStudio_*\Capabilities'
-                }
+            [string] $vs2017RootPath = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
+            [string] $applicationDescription1 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
+            [string] $applicationDescription2 = "@$(Join-Path $vs2017RootPath ([IO.Path]::GetRandomFileName()))\Common7\IDE\devenvdesc.dll,-1234"
+            Mock Get-ItemProperty -MockWith {
+                @{ ApplicationDescription = $applicationDescription1 }
+                @{ ApplicationDescription = $applicationDescription2 }
+            }.GetNewClosure() -ParameterFilter {
+                $Path -eq 'HKLM:\SOFTWARE\Microsoft\VisualStudio_*\Capabilities'
+            }
 
+            It 'Returns ApplicationDescription property from HKLM:\SOFTWARE' {
                 Get-VisualStudio2017ApplicationDescription | Should Be @(
                     $applicationDescription1
                     $applicationDescription2

--- a/test/posh-vs.tests.ps1
+++ b/test/posh-vs.tests.ps1
@@ -159,11 +159,7 @@ Describe 'Get-VisualStudio2015BatchFile' {
     Import-Module $PSScriptRoot\..\src\posh-vs.psm1
 
     InModuleScope posh-vs {
-        [string] $originalPath
-
-        BeforeEach {
-            $originalPath = $env:VS140ComnTools
-        }
+        [string] $originalPath = $env:VS140ComnTools
 
         Context '$env:V140ComnTools is defined' {
             $env:VS140ComnTools = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())
@@ -183,9 +179,7 @@ Describe 'Get-VisualStudio2015BatchFile' {
             }
         }
 
-        AfterEach {
-            $env:VS140ComnTools = $originalPath
-        }
+        $env:VS140ComnTools = $originalPath
     }
 
     Remove-Module posh-vs


### PR DESCRIPTION
- Make `Import-VisualStudioEnvironment` use `VsDevCmd.bat` of the latest installed version of Visual Studio. 
- Update `readme.md` with instructions on how to use `Import-BatchEnvironment` to explicitly choose the desired instance of Visual Studio 2017.
- Add `.vscode/launch.json` to enable debugging tests.
- Increment module version from `0.1` to `0.2`.